### PR TITLE
[FIX] 기존 회원 토큰 중복 저장 오류 해결

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -16,54 +16,62 @@ export class AuthService {
     private readonly jwtService: JwtService,
   ) {}
 
-  async kakaoLogin(req: SocialRequest, res: Response) {
-    try {
-      const { user } = req;
-
-      // 유저 중복 검사
-      let findUser = await this.userService.findOneBySocialId(user.socialId);
-
+  private async handleSocialLogin(user: SocialRequest['user'], res: Response) {
+    // 유저 중복 검사
+    let findUser = await this.userService.findOneBySocialId(user.socialId);
+    if (!findUser) {
       // 없는 유저면 DB에 유저정보 저장
-      if (!findUser) {
-        const uuid = uuidv4();
-        findUser = await this.userService.createUser(user, uuid);
-      }
+      const uuid = uuidv4();
+      findUser = await this.userService.createUser(user, uuid);
+    }
 
-      console.log(findUser);
+    // 카카오 가입이 되어 있는 경우 accessToken 및 refreshToken 발급
+    const findUserPayload = { userUuid: findUser.userUuid };
+    const access_token = await this.jwtService.sign(findUserPayload, {
+      secret: process.env.JWT_ACCESS_TOKEN_SECRET,
+      expiresIn: '30m',
+    });
 
-      // 카카오 가입이 되어 있는 경우 accessToken 및 refreshToken 발급
-      const findUserPayload = { userUuid: findUser.userUuid };
-      const access_token = await this.jwtService.sign(findUserPayload, {
-        secret: process.env.JWT_ACCESS_TOKEN_SECRET,
-        expiresIn: '30m',
-      });
+    const refresh_token = await this.jwtService.sign(findUserPayload, {
+      secret: process.env.JWT_REFRESH_TOKEN_SECRET,
+      expiresIn: '14d',
+    });
 
-      const refresh_token = await this.jwtService.sign(findUserPayload, {
-        secret: process.env.JWT_REFRESH_TOKEN_SECRET,
-        expiresIn: '14d',
-      });
+    const userId = await this.userService.findOneById(findUser.userUuid);
+    const existingAuth = await this.authRepository.findOne({
+      where: { userId },
+    });
 
-      // Auth 정보 DB에 저장(기존 회원이면 update, 신규회원이면 save? 아직 암호화 X)
-      const userId = await this.userService.findOneById(findUser.userUuid);
-      const findAuth = await this.authRepository.create({
+    if (existingAuth) {
+      existingAuth.refreshToken = refresh_token;
+      await this.authRepository.save(existingAuth);
+    } else {
+      const newAuth = await this.authRepository.create({
         userId,
         refreshToken: refresh_token,
       });
-      await this.authRepository.save(findAuth);
+      await this.authRepository.save(newAuth);
+    }
 
-      // 쿠키 설정
-      const now = new Date();
-      now.setDate(now.getDate() + +'14d');
-      res.cookie('frefresh_token', refresh_token, {
-        expires: now,
-        httpOnly: true,
-        // secure: process.env.NODE_ENV === 'production' ? true : false,
-        // sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
-      });
-      return {
-        ok: true,
-        access_token,
-      };
+    // 쿠키 설정 (프론트로 어떻게 넘길지 고민중)
+    const now = new Date();
+    now.setDate(now.getDate() + 14);
+    res.cookie('frefresh_token', refresh_token, {
+      expires: now,
+      httpOnly: true,
+      // secure: process.env.NODE_ENV === 'production' ? true : false,
+      // sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
+    });
+    return {
+      ok: true,
+      access_token,
+    };
+  }
+
+  async kakaoLogin(req: SocialRequest, res: Response) {
+    try {
+      const { user } = req;
+      return await this.handleSocialLogin(user, res);
     } catch (error) {
       console.log(error);
       return { ok: false, error: '카카오 로그인 인증을 실패하였습니다.' };
@@ -75,50 +83,7 @@ export class AuthService {
     try {
       const { user } = req;
 
-      // 유저 중복 검사
-      let findUser = await this.userService.findOneBySocialId(user.socialId);
-
-      // 없는 유저면 DB에 유저정보 저장
-      if (!findUser) {
-        const uuid = uuidv4();
-        findUser = await this.userService.createUser(user, uuid);
-      }
-
-      console.log(findUser);
-
-      // 카카오 가입이 되어 있는 경우 accessToken 및 refreshToken 발급
-      const findUserPayload = { userUuid: findUser.userUuid };
-      const access_token = await this.jwtService.sign(findUserPayload, {
-        secret: process.env.JWT_ACCESS_TOKEN_SECRET,
-        expiresIn: '30m',
-      });
-
-      const refresh_token = await this.jwtService.sign(findUserPayload, {
-        secret: process.env.JWT_REFRESH_TOKEN_SECRET,
-        expiresIn: '14d',
-      });
-
-      // Auth 정보 DB에 저장(기존 회원이면 update, 신규회원이면 save? 아직 암호화 X)
-      const userId = await this.userService.findOneById(findUser.userUuid);
-      const findAuth = await this.authRepository.create({
-        userId,
-        refreshToken: refresh_token,
-      });
-      await this.authRepository.save(findAuth);
-
-      // 쿠키 설정
-      const now = new Date();
-      now.setDate(now.getDate() + +'14d');
-      res.cookie('frefresh_token', refresh_token, {
-        expires: now,
-        httpOnly: true,
-        // secure: process.env.NODE_ENV === 'production' ? true : false,
-        // sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
-      });
-      return {
-        ok: true,
-        access_token,
-      };
+      return this.handleSocialLogin(user, res);
     } catch (error) {
       console.log(error);
       return { ok: false, error: '네이버 로그인 인증을 실패하였습니다.' };

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -66,7 +66,7 @@ export class AuthService {
       };
     } catch (error) {
       console.log(error);
-      return { ok: false, error: '구글 로그인 인증을 실패하였습니다.' };
+      return { ok: false, error: '카카오 로그인 인증을 실패하였습니다.' };
     }
   }
 
@@ -121,7 +121,7 @@ export class AuthService {
       };
     } catch (error) {
       console.log(error);
-      return { ok: false, error: '구글 로그인 인증을 실패하였습니다.' };
+      return { ok: false, error: '네이버 로그인 인증을 실패하였습니다.' };
     }
   }
 }


### PR DESCRIPTION
## 🔗 이슈 번호
#27 
## ✅ 작업 내용
- 기존 회원이 다시 로그인할 때 토큰이 중복 저장되는 오류 해결했습니다.
- 네이버, 카카오 로그인 중복 코드도 공통 함수로 분리

## 🗣️ 공유 사항
- 현재 쿠키에다가 저장해서 보내주고 있는데 추후 수정 예정입니다.