### PR TITLE
[REFACTOR] userUuid 조회 로직 user 모듈로 이전

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { HttpLoggerMiddleware } from './middlewares/http-logger.middleware';
 import { CommentsModule } from './modules/comments/comments.module';
 import { LikesModule } from './modules/likes/likes.module';
 import { UsersModule } from './modules/users/users.module';
+import { GroupModule } from './modules/group/group.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { UsersModule } from './modules/users/users.module';
     CommentsModule,
     LikesModule,
     UsersModule,
+    GroupModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -44,7 +44,7 @@ export class AuthService {
       });
 
       // Auth 정보 DB에 저장(기존 회원이면 update, 신규회원이면 save? 아직 암호화 X)
-      const userId = await this.userService.findOneById(findUser.userUuid);
+      const userId = await this.userService.getUserIdByUuid(findUser.userUuid);
       const findAuth = await this.authRepository.create({
         userId,
         refreshToken: refresh_token,
@@ -53,8 +53,8 @@ export class AuthService {
 
       // 쿠키 설정
       const now = new Date();
-      now.setDate(now.getDate() + +'14d');
-      res.cookie('frefresh_token', refresh_token, {
+      now.setDate(now.getDate() + 14);
+      res.cookie('refresh_token', refresh_token, {
         expires: now,
         httpOnly: true,
         // secure: process.env.NODE_ENV === 'production' ? true : false,
@@ -99,7 +99,7 @@ export class AuthService {
       });
 
       // Auth 정보 DB에 저장(기존 회원이면 update, 신규회원이면 save? 아직 암호화 X)
-      const userId = await this.userService.findOneById(findUser.userUuid);
+      const userId = await this.userService.getUserIdByUuid(findUser.userUuid);
       const findAuth = await this.authRepository.create({
         userId,
         refreshToken: refresh_token,
@@ -108,8 +108,8 @@ export class AuthService {
 
       // 쿠키 설정
       const now = new Date();
-      now.setDate(now.getDate() + +'14d');
-      res.cookie('frefresh_token', refresh_token, {
+      now.setDate(now.getDate() + 14);
+      res.cookie('refresh_token', refresh_token, {
         expires: now,
         httpOnly: true,
         // secure: process.env.NODE_ENV === 'production' ? true : false,

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -15,7 +15,7 @@ export class User {
   @Column({ name: 'user_uuid', type: 'uuid', unique: true })
   userUuid: string;
 
-  @Column({ name: 'nickname', type: 'varchar', unique: true })
+  @Column({ name: 'nickname', type: 'varchar' })
   nickname: string;
 
   @Column({ name: 'profile_image', type: 'varchar', nullable: true })

--- a/src/modules/comments/comments.module.ts
+++ b/src/modules/comments/comments.module.ts
@@ -5,10 +5,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostsModule } from '@/modules/posts/posts.module';
 import { Comment } from '@/entities/comment.entity';
 import { User } from '@/entities/user.entity';
+import { UsersModule } from '../users/users.module';
 @Module({
   imports: [
     TypeOrmModule.forFeature([Comment, User]),
     forwardRef(() => PostsModule),
+    forwardRef(() => UsersModule),
   ],
   controllers: [CommentsController],
   providers: [CommentsService],

--- a/src/modules/comments/comments.service.ts
+++ b/src/modules/comments/comments.service.ts
@@ -12,6 +12,7 @@ import { PostsService } from '@/modules/posts/posts.service';
 import { FindAllCommentsDto } from './dto/find-all-comments.dto';
 import { Comment } from '@/entities/comment.entity';
 import { User } from '@/entities/user.entity';
+import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class CommentsService {
@@ -22,6 +23,7 @@ export class CommentsService {
     private postsService: PostsService,
     @InjectRepository(User)
     private userRepository: Repository<User>,
+    private userService: UsersService,
   ) {}
 
   /**
@@ -33,7 +35,9 @@ export class CommentsService {
     // 게시글 존재 여부 확인
     await this.postsService.findOnePost(createCommentDto.postId);
 
-    const userId = await this.getUserIdByUuid(createCommentDto.userUuid);
+    const userId = await this.userService.getUserIdByUuid(
+      createCommentDto.userUuid,
+    );
 
     const comment = this.commentRepository.create({
       ...createCommentDto,
@@ -241,25 +245,5 @@ export class CommentsService {
     });
 
     return commentCountMap;
-  }
-
-  /**
-   * userUuid로 userId 조회 (user.service로 추후 이동 예정)
-   * @param userUuid 사용자 UUID
-   * @returns 사용자 ID
-   */
-  async getUserIdByUuid(userUuid: string): Promise<number> {
-    const user = await this.userRepository.findOne({
-      where: { userUuid },
-      select: ['id'],
-    });
-
-    if (!user) {
-      throw new NotFoundException(
-        `UUID ${userUuid}에 해당하는 사용자를 찾을 수 없습니다.`,
-      );
-    }
-
-    return user.id;
   }
 }

--- a/src/modules/group/dto/create-group.dto.ts
+++ b/src/modules/group/dto/create-group.dto.ts
@@ -1,0 +1,1 @@
+export class CreateGroupDto {}

--- a/src/modules/group/dto/update-group.dto.ts
+++ b/src/modules/group/dto/update-group.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateGroupDto } from './create-group.dto';
+
+export class UpdateGroupDto extends PartialType(CreateGroupDto) {}

--- a/src/modules/group/group.controller.spec.ts
+++ b/src/modules/group/group.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupController } from './group.controller';
+import { GroupService } from './group.service';
+
+describe('GroupController', () => {
+  let controller: GroupController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GroupController],
+      providers: [GroupService],
+    }).compile();
+
+    controller = module.get<GroupController>(GroupController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { GroupService } from './group.service';
+import { CreateGroupDto } from './dto/create-group.dto';
+import { UpdateGroupDto } from './dto/update-group.dto';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('group')
+@Controller('group')
+export class GroupController {
+  constructor(private readonly groupService: GroupService) {}
+
+  @Post()
+  create(@Body() createGroupDto: CreateGroupDto) {
+    return this.groupService.create(createGroupDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.groupService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.groupService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateGroupDto: UpdateGroupDto) {
+    return this.groupService.update(+id, updateGroupDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.groupService.remove(+id);
+  }
+}

--- a/src/modules/group/group.module.ts
+++ b/src/modules/group/group.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { GroupService } from './group.service';
+import { GroupController } from './group.controller';
+
+@Module({
+  controllers: [GroupController],
+  providers: [GroupService],
+})
+export class GroupModule {}

--- a/src/modules/group/group.service.spec.ts
+++ b/src/modules/group/group.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GroupService } from './group.service';
+
+describe('GroupService', () => {
+  let service: GroupService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GroupService],
+    }).compile();
+
+    service = module.get<GroupService>(GroupService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateGroupDto } from './dto/create-group.dto';
+import { UpdateGroupDto } from './dto/update-group.dto';
+
+@Injectable()
+export class GroupService {
+  create(createGroupDto: CreateGroupDto) {
+    return 'This action adds a new group';
+  }
+
+  findAll() {
+    return `This action returns all group`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} group`;
+  }
+
+  update(id: number, updateGroupDto: UpdateGroupDto) {
+    return `This action updates a #${id} group`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} group`;
+  }
+}

--- a/src/modules/likes/likes.module.ts
+++ b/src/modules/likes/likes.module.ts
@@ -5,11 +5,13 @@ import { Like } from '@/entities/like.entity';
 import { User } from '@/entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostsModule } from '../posts/posts.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Like, User]),
     forwardRef(() => PostsModule),
+    forwardRef(() => UsersModule),
   ],
   controllers: [LikesController],
   providers: [LikesService],

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -1,12 +1,14 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { User } from '@/entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { LikesModule } from '../likes/likes.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => LikesModule)],
   controllers: [UsersController],
   providers: [UsersService],
+  exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,31 +1,46 @@
 import { User } from '@/entities/user.entity';
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 @Injectable()
 export class UsersService {
-  constructor(@InjectRepository(User) private repo: Repository<User>) {}
+  constructor(
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+  ) {}
 
   findOneBySocialId(socialId: string) {
-    return this.repo.findOneBy({ socialId });
-  }
-
-  async findOneById(userUuid: string) {
-    const user = await this.repo.findOne({ where: { userUuid } });
-    if (!user) {
-      throw new Error('not found user!');
-    }
-    return user.id;
+    return this.userRepository.findOneBy({ socialId });
   }
 
   createUser(user, uuid): Promise<User> {
-    const newUser = this.repo.create({
+    const newUser = this.userRepository.create({
       userUuid: uuid,
       nickname: user.nickname,
       profileImage: user.profileImage,
       socialProvider: user.socialProvider,
       socialId: user.socialId,
     });
-    return this.repo.save(newUser);
+    return this.userRepository.save(newUser);
+  }
+
+  /**
+   * userUuid로 userId 조회
+   * @param userUuid 사용자 UUID
+   * @returns 사용자 ID
+   */
+  async getUserIdByUuid(userUuid: string): Promise<number> {
+    const user = await this.userRepository.findOne({
+      where: { userUuid },
+      select: ['id'],
+    });
+
+    if (!user) {
+      throw new NotFoundException(
+        `UUID ${userUuid}에 해당하는 사용자를 찾을 수 없습니다.`,
+      );
+    }
+
+    return user.id;
   }
 }

--- a/src/types/payload.type.ts
+++ b/src/types/payload.type.ts
@@ -1,0 +1,3 @@
+export interface payloadType {
+  userUuid: string;
+}

--- a/src/types/tokenPayloadType.ts
+++ b/src/types/tokenPayloadType.ts
@@ -1,3 +1,0 @@
-export interface tokenPayloadType {
-  userUuid: string;
-}


### PR DESCRIPTION
## 🔗 이슈 번호
#26 
## ✅ 작업 내용
- 기존 다른 모듈에서 사용하던 userId → userUuid 조회 기능을 user 모듈로 이동
- 기능의 응집도를 높이고, 재사용성을 고려하여 공통 기능을 user 도메인에서 관리하도록 리팩토링
## 🗣️ 공유 사항
- 추후 user 도메인 중심으로 사용자 관련 조회 로직을 통합할 예정