### PR TITLE
[FEAT] Group API

### DIFF
--- a/database/seeds/group.seeder.ts
+++ b/database/seeds/group.seeder.ts
@@ -25,8 +25,8 @@ export class GroupSeeder implements Seeder {
         password: null,
         isAccessible: true,
         maxMember: 4,
-        ownerId: users[0].userUuid,
-        memberId: [
+        ownerUuid: users[0].userUuid,
+        memberUuid: [
           users[0].userUuid,
           users[1].userUuid,
           users[2].userUuid,
@@ -41,7 +41,7 @@ export class GroupSeeder implements Seeder {
       const existingGroup = await groupRepository.findOne({
         where: {
           title: groupData.title,
-          ownerId: groupData.ownerId,
+          ownerUuid: groupData.ownerUuid,
         },
       });
 

--- a/src/decorators/swagger.decorator.ts
+++ b/src/decorators/swagger.decorator.ts
@@ -1437,3 +1437,826 @@ export function ApiDeleteLike() {
     }),
   );
 }
+
+export function ApiCreateGroup() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '그룹 생성',
+      description: '새로운 그룹을 생성합니다.',
+    }),
+    ApiQuery({
+      name: 'ownerUuid',
+      description: '방장 UUID',
+      required: true,
+      type: 'string',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: '그룹 제목',
+            example: '같이 운동해요',
+          },
+          password: {
+            type: 'string',
+            description: '그룹 비밀번호 (선택사항)',
+            example: '1234',
+          },
+          isAccessible: {
+            type: 'boolean',
+            description: '그룹 공개 여부',
+            example: false,
+          },
+          maxMember: {
+            type: 'number',
+            description: '최대 멤버 수',
+            example: 4,
+          },
+        },
+        required: ['title'],
+      },
+    }),
+    ApiResponse({
+      status: 201,
+      description: '그룹이 성공적으로 생성됨',
+      schema: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            example: 1,
+          },
+          ownerUuid: {
+            type: 'string',
+            example: '123e4567-e89b-12d3-a456-426614174000',
+          },
+          memberUuid: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            example: ['123e4567-e89b-12d3-a456-426614174000'],
+          },
+          title: {
+            type: 'string',
+            example: '같이 운동해요',
+          },
+          password: {
+            type: 'string',
+            example: '1234',
+          },
+          isAccessible: {
+            type: 'boolean',
+            example: false,
+          },
+          maxMember: {
+            type: 'number',
+            example: 4,
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T10:00:00.000Z',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T10:00:00.000Z',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: 'Validation 오류',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'array',
+            example: ['title must be a string', 'title should not be empty'],
+          },
+          error: {
+            type: 'string',
+            example: 'Bad Request',
+          },
+          statusCode: {
+            type: 'number',
+            example: 400,
+          },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiUpdateGroup() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '그룹 수정',
+      description: '그룹 방장이 특정 ID의 그룹을 수정합니다.',
+    }),
+    ApiParam({
+      name: 'groupId',
+      description: '수정할 그룹 ID',
+      required: true,
+      type: 'string',
+      example: '1',
+    }),
+    ApiParam({
+      name: 'ownerUuid',
+      description: '방장 UUID',
+      required: true,
+      type: 'string',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: '그룹 제목',
+            example: '수정된 그룹 제목',
+          },
+          password: {
+            type: 'string',
+            description: '그룹 비밀번호 (선택사항)',
+            example: '7890',
+          },
+          isAccessible: {
+            type: 'boolean',
+            description: '그룹 공개 여부',
+            example: false,
+          },
+          maxMember: {
+            type: 'number',
+            description: '최대 멤버 수',
+            example: 6,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 200,
+      description: '그룹이 성공적으로 수정됨',
+      schema: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            example: 1,
+          },
+          ownerUuid: {
+            type: 'string',
+            example: '123e4567-e89b-12d3-a456-426614174000',
+          },
+          memberUuid: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            example: [
+              '123e4567-e89b-12d3-a456-426614174000',
+              '123e4567-e89b-12d3-a456-426614174001',
+            ],
+          },
+          title: {
+            type: 'string',
+            example: '수정된 그룹 제목',
+          },
+          password: {
+            type: 'string',
+            example: '7890',
+          },
+          isAccessible: {
+            type: 'boolean',
+            example: false,
+          },
+          maxMember: {
+            type: 'number',
+            example: 6,
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T10:00:00.000Z',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T10:30:00.000Z',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '그룹을 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '해당 ID의 그룹을 찾을 수 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Not Found',
+          },
+          statusCode: {
+            type: 'number',
+            example: 404,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '권한 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '이 그룹을 수정할 권한이 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Unauthorized',
+          },
+          statusCode: {
+            type: 'number',
+            example: 403,
+          },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiDeleteGroup() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '그룹 삭제',
+      description: '그룹 방장이 특정 ID의 그룹을 삭제합니다.',
+    }),
+    ApiParam({
+      name: 'groupId',
+      description: '삭제할 그룹 ID',
+      required: true,
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '그룹이 성공적으로 삭제됨',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '그룹이 성공적으로 삭제되었습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '그룹을 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '해당 ID의 그룹을 찾을 수 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Not Found',
+          },
+          statusCode: {
+            type: 'number',
+            example: 404,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '권한 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '이 그룹을 삭제할 권한이 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Unauthorized',
+          },
+          statusCode: {
+            type: 'number',
+            example: 403,
+          },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiGetAllGroups() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '모든 공개 그룹 조회',
+      description: '모든 공개 그룹을 조회합니다.',
+    }),
+    ApiQuery({
+      name: 'page',
+      required: false,
+      description: '페이지 번호 (default: 1)',
+      type: 'number',
+      example: 1,
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      description: '페이지당 그룹 수 (default: 10)',
+      type: 'number',
+      example: 10,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '공개 그룹 목록 조회 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          data: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'number',
+                  example: 1,
+                },
+                ownerUuid: {
+                  type: 'string',
+                  example: '123e4567-e89b-12d3-a456-426614174000',
+                },
+                memberUuid: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                  example: [
+                    '123e4567-e89b-12d3-a456-426614174000',
+                    '123e4567-e89b-12d3-a456-426614174001',
+                  ],
+                },
+                title: {
+                  type: 'string',
+                  example: '같이 운동해요',
+                },
+                isAccessible: {
+                  type: 'boolean',
+                  example: true,
+                },
+                maxMember: {
+                  type: 'number',
+                  example: 4,
+                },
+                createdAt: {
+                  type: 'string',
+                  format: 'date-time',
+                  example: '2025-03-31T10:00:00.000Z',
+                },
+                updatedAt: {
+                  type: 'string',
+                  format: 'date-time',
+                  example: '2025-03-31T10:00:00.000Z',
+                },
+              },
+            },
+          },
+          meta: {
+            type: 'object',
+            properties: {
+              totalItems: {
+                type: 'number',
+                example: 25,
+              },
+              itemsPerPage: {
+                type: 'number',
+                example: 10,
+              },
+              totalPages: {
+                type: 'number',
+                example: 3,
+              },
+              currentPage: {
+                type: 'number',
+                example: 1,
+              },
+            },
+          },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiGetGroup() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '그룹 상세 조회',
+      description: '특정 ID의 그룹을 상세하게 조회합니다.',
+    }),
+    ApiParam({
+      name: 'groupId',
+      description: '조회할 그룹 ID',
+      required: true,
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '그룹 상세 조회 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            example: 1,
+          },
+          ownerUuid: {
+            type: 'string',
+            example: '123e4567-e89b-12d3-a456-426614174000',
+          },
+          memberUuid: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            example: [
+              '123e4567-e89b-12d3-a456-426614174000',
+              '123e4567-e89b-12d3-a456-426614174001',
+            ],
+          },
+          title: {
+            type: 'string',
+            example: '같이 운동해요',
+          },
+          isAccessible: {
+            type: 'boolean',
+            example: true,
+          },
+          maxMember: {
+            type: 'number',
+            example: 4,
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T10:00:00.000Z',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T10:00:00.000Z',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '그룹을 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '해당 ID의 그룹을 찾을 수 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Not Found',
+          },
+          statusCode: {
+            type: 'number',
+            example: 404,
+          },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiJoinGroup() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '그룹 참여',
+      description:
+        '특정 그룹에 참여합니다. 비공개 그룹인 경우 비밀번호가 필요합니다.',
+    }),
+    ApiParam({
+      name: 'groupId',
+      description: '참여할 그룹 ID',
+      required: true,
+      type: 'string',
+      example: '1',
+    }),
+    ApiQuery({
+      name: 'userUuid',
+      description: '사용자 UUID',
+      required: true,
+      type: 'string',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          password: {
+            type: 'string',
+            description: '그룹 비밀번호 (비공개 그룹인 경우 필요)',
+            example: '1234',
+          },
+        },
+        required: [],
+      },
+    }),
+    ApiResponse({
+      status: 200,
+      description: '그룹 참여 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            example: 1,
+          },
+          ownerUuid: {
+            type: 'string',
+            example: '123e4567-e89b-12d3-a456-426614174000',
+          },
+          memberUuid: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            example: [
+              '123e4567-e89b-12d3-a456-426614174000',
+              '123e4567-e89b-12d3-a456-426614174001',
+            ],
+          },
+          title: {
+            type: 'string',
+            example: '같이 운동해요',
+          },
+          isAccessible: {
+            type: 'boolean',
+            example: true,
+          },
+          maxMember: {
+            type: 'number',
+            example: 4,
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T10:00:00.000Z',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T11:00:00.000Z',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '이미 그룹에 가입되어 있습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Bad Request',
+          },
+          statusCode: {
+            type: 'number',
+            example: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 401,
+      description: '인증 오류',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '비밀번호가 일치하지 않습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Unauthorized',
+          },
+          statusCode: {
+            type: 'number',
+            example: 401,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '그룹을 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '해당 ID의 그룹을 찾을 수 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Not Found',
+          },
+          statusCode: {
+            type: 'number',
+            example: 404,
+          },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiLeaveGroup() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '그룹 탈퇴',
+      description: '그룹에서 탈퇴합니다. 방장은 그룹을 탈퇴할 수 없습니다.',
+    }),
+    ApiQuery({
+      name: 'userUuid',
+      description: '사용자 UUID',
+      required: true,
+      type: 'string',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '그룹 탈퇴 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '그룹에서 성공적으로 탈퇴했습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '방장은 그룹을 탈퇴할 수 없습니다. 그룹을 삭제하세요.',
+          },
+          error: {
+            type: 'string',
+            example: 'Bad Request',
+          },
+          statusCode: {
+            type: 'number',
+            example: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '그룹을 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '해당 ID의 그룹을 찾을 수 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Not Found',
+          },
+          statusCode: {
+            type: 'number',
+            example: 404,
+          },
+        },
+      },
+    }),
+  );
+}
+
+export function ApiGetUserGroup() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '사용자가 속한 그룹 조회',
+      description:
+        '사용자가 현재 속한 그룹을 조회합니다. 한 사용자는 최대 하나의 그룹에만 속할 수 있습니다.',
+    }),
+    ApiQuery({
+      name: 'userUuid',
+      description: '사용자 UUID',
+      required: true,
+      type: 'string',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '사용자가 속한 그룹 정보',
+      schema: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            example: 1,
+          },
+          ownerUuid: {
+            type: 'string',
+            example: '123e4567-e89b-12d3-a456-426614174000',
+          },
+          memberUuid: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            example: [
+              '123e4567-e89b-12d3-a456-426614174000',
+              '123e4567-e89b-12d3-a456-426614174001',
+            ],
+          },
+          title: {
+            type: 'string',
+            example: '같이 운동해요',
+          },
+          isAccessible: {
+            type: 'boolean',
+            example: true,
+          },
+          maxMember: {
+            type: 'number',
+            example: 4,
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T10:00:00.000Z',
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            example: '2025-03-31T11:00:00.000Z',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '사용자 UUID가 필요합니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Bad Request',
+          },
+          statusCode: {
+            type: 'number',
+            example: 400,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/entities/group.entity.ts
+++ b/src/entities/group.entity.ts
@@ -5,11 +5,11 @@ export class Group {
   @PrimaryGeneratedColumn({ name: 'id' })
   id: number;
 
-  @Column({ name: 'owner_id', type: 'uuid' })
-  ownerId: string;
+  @Column({ name: 'owner_uuid', type: 'uuid' })
+  ownerUuid: string;
 
-  @Column({ name: 'member_id', type: 'uuid', array: true, default: '{}' })
-  memberId: string[];
+  @Column({ name: 'member_uuid', type: 'uuid', array: true, default: '{}' })
+  memberUuid: string[];
 
   @Column({ name: 'title', type: 'varchar' })
   title: string;

--- a/src/modules/group/dto/create-group.dto.ts
+++ b/src/modules/group/dto/create-group.dto.ts
@@ -1,1 +1,31 @@
-export class CreateGroupDto {}
+import { IsBoolean, IsDate, IsNumber } from 'class-validator';
+
+import { IsOptional } from 'class-validator';
+
+import { IsNotEmpty } from 'class-validator';
+
+import { IsString } from 'class-validator';
+
+export class CreateGroupDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  password?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isAccessible?: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  maxMember?: number;
+
+  @IsDate()
+  createdAt: Date = new Date();
+
+  @IsDate()
+  updatedAt: Date = new Date();
+}

--- a/src/modules/group/dto/find-all-groups.dto.ts
+++ b/src/modules/group/dto/find-all-groups.dto.ts
@@ -1,0 +1,14 @@
+import { Type } from 'class-transformer';
+import { IsNumber, Min } from 'class-validator';
+
+export class FindAllGroupsDto {
+  @IsNumber()
+  @Type(() => Number)
+  @Min(1)
+  page: number = 1;
+
+  @IsNumber()
+  @Type(() => Number)
+  @Min(1)
+  limit: number = 10;
+}

--- a/src/modules/group/dto/group-list-response.dto.ts
+++ b/src/modules/group/dto/group-list-response.dto.ts
@@ -1,0 +1,11 @@
+import { GroupResponseDto } from './group-response.dto';
+
+export class GroupListResponseDto {
+  data: GroupResponseDto[];
+  meta: {
+    totalItems: number;
+    itemsPerPage: number;
+    totalPages: number;
+    currentPage: number;
+  };
+}

--- a/src/modules/group/dto/group-response.dto.ts
+++ b/src/modules/group/dto/group-response.dto.ts
@@ -1,0 +1,11 @@
+export class GroupResponseDto {
+  id: number;
+  ownerId: string;
+  memberId: string[];
+  title: string;
+  password?: string;
+  isAccessible: boolean;
+  maxMember: number;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/modules/group/dto/join-group.dto.ts
+++ b/src/modules/group/dto/join-group.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class JoinGroupDto {
+  @IsString()
+  @IsOptional()
+  password?: string;
+}

--- a/src/modules/group/dto/update-group.dto.ts
+++ b/src/modules/group/dto/update-group.dto.ts
@@ -1,4 +1,6 @@
-import { PartialType } from '@nestjs/swagger';
+import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateGroupDto } from './create-group.dto';
 
-export class UpdateGroupDto extends PartialType(CreateGroupDto) {}
+export class UpdateGroupDto extends PartialType(
+  OmitType(CreateGroupDto, ['createdAt']),
+) {}

--- a/src/modules/group/group.controller.ts
+++ b/src/modules/group/group.controller.ts
@@ -6,39 +6,146 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
 } from '@nestjs/common';
 import { GroupService } from './group.service';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { UpdateGroupDto } from './dto/update-group.dto';
 import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiCreateGroup,
+  ApiGetAllGroups,
+  ApiGetGroup,
+  ApiUpdateGroup,
+  ApiDeleteGroup,
+  ApiJoinGroup,
+  ApiLeaveGroup,
+  ApiGetUserGroup,
+} from '@/decorators/swagger.decorator';
+import { FindAllGroupsDto } from './dto/find-all-groups.dto';
+import { JoinGroupDto } from './dto/join-group.dto';
 
 @ApiTags('group')
 @Controller('group')
 export class GroupController {
   constructor(private readonly groupService: GroupService) {}
 
+  /**
+   * 사용자가 속한 그룹 조회
+   * @param userUuid 사용자 UUID
+   * @returns 사용자가 속한 그룹 정보 또는 null
+   */
+  @Get('user')
+  @ApiGetUserGroup()
+  getUserGroup(@Query('userUuid') userUuid: string) {
+    return this.groupService.findUserCurrentGroup(userUuid);
+  }
+
+  /**
+   * 그룹 생성
+   * @param createGroupDto 그룹 생성 정보
+   * @param ownerUuid 방장 UUID
+   * @returns 생성된 그룹 정보
+   */
   @Post()
-  create(@Body() createGroupDto: CreateGroupDto) {
-    return this.groupService.create(createGroupDto);
+  @ApiCreateGroup()
+  createGroup(
+    @Body() createGroupDto: CreateGroupDto,
+    @Query('ownerUuid') ownerUuid: string,
+  ) {
+    // TODO: user req
+    return this.groupService.createGroup(createGroupDto, ownerUuid);
   }
 
+  /**
+   * 모든 공개 그룹 조회
+   * @param findAllGroupsDto 그룹 목록 조회 조건들
+   * @returns 모든 공개 그룹 정보
+   */
   @Get()
-  findAll() {
-    return this.groupService.findAll();
+  @ApiGetAllGroups()
+  findAccessibleGroups(@Query() findAllGroupsDto: FindAllGroupsDto) {
+    return this.groupService.findAccessibleGroups(findAllGroupsDto);
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.groupService.findOne(+id);
+  /**
+   * 그룹 상세 조회
+   * @param id 그룹 ID
+   * @returns 그룹 상세 정보
+   */
+  @Get(':groupId')
+  @ApiGetGroup()
+  findOneGroup(@Param('groupId') groupId: string) {
+    return this.groupService.findOneGroup(+groupId);
   }
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateGroupDto: UpdateGroupDto) {
-    return this.groupService.update(+id, updateGroupDto);
+  /**
+   * 그룹 수정
+   * @param groupId 그룹 ID
+   * @param updateGroupDto 그룹 수정 정보
+   * @param ownerUuid 방장 UUID
+   * @returns 수정된 그룹 정보
+   */
+  @Patch(':groupId')
+  @ApiUpdateGroup()
+  updateGroup(
+    @Param('groupId') groupId: string,
+    @Body() updateGroupDto: UpdateGroupDto,
+    // TODO: user req
+    @Query('ownerUuid') ownerUuid: string,
+  ) {
+    return this.groupService.updateGroup(+groupId, updateGroupDto, ownerUuid);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.groupService.remove(+id);
+  /**
+   * 그룹 삭제
+   * @param groupId 그룹 ID
+   * @param ownerUuid 방장 UUID
+   */
+  @Delete(':groupId')
+  @ApiDeleteGroup()
+  removeGroup(
+    @Param('groupId') groupId: string,
+    @Query('ownerUuid') ownerUuid: string,
+  ) {
+    // TODO: user req
+    return this.groupService.deleteGroup(+groupId, ownerUuid);
+  }
+
+  /**
+   * 그룹 참여
+   * @param groupId 그룹 ID
+   * @param userUuid 사용자 UUID
+   * @returns 참여된 그룹 정보
+   */
+  @Post(':groupId/join')
+  @ApiJoinGroup()
+  joinGroup(
+    @Param('groupId') groupId: string,
+    @Query('userUuid') userUuid: string,
+    @Body() joinGroupDto: JoinGroupDto,
+  ) {
+    // TODO: user req
+    return this.groupService.joinGroup(
+      +groupId,
+      userUuid,
+      joinGroupDto.password,
+    );
+  }
+
+  /**
+   * 그룹 탈퇴
+   * @param groupId 그룹 ID
+   * @param userUuid 사용자 UUID
+   * @returns 탈퇴 메시지
+   */
+  @Delete(':groupId/leave')
+  @ApiLeaveGroup()
+  leaveGroup(
+    @Param('groupId') groupId: string,
+    @Query('userUuid') userUuid: string,
+  ) {
+    // TODO: user req
+    return this.groupService.leaveGroup(+groupId, userUuid);
   }
 }

--- a/src/modules/group/group.module.ts
+++ b/src/modules/group/group.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { GroupService } from './group.service';
 import { GroupController } from './group.controller';
+import { Group } from '@/entities/group.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { UsersModule } from '../users/users.module';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Group]), UsersModule],
   controllers: [GroupController],
   providers: [GroupService],
 })

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -1,26 +1,365 @@
-import { Injectable } from '@nestjs/common';
+import { Group } from '@/entities/group.entity';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Like } from 'typeorm';
 import { CreateGroupDto } from './dto/create-group.dto';
 import { UpdateGroupDto } from './dto/update-group.dto';
 
 @Injectable()
 export class GroupService {
-  create(createGroupDto: CreateGroupDto) {
-    return 'This action adds a new group';
+  constructor(
+    @InjectRepository(Group)
+    private groupRepository: Repository<Group>,
+  ) {}
+
+  /**
+   * 사용자가 소속된 그룹 찾기
+   * @param userUuid 사용자 UUID
+   * @returns 사용자가 소속된 그룹 또는 null
+   */
+  private async findUserGroup(userUuid: string): Promise<Group | null> {
+    // memberUuid 배열에 사용자 UUID가 포함된 그룹 찾기
+    const groups = await this.groupRepository.find({
+      where: {},
+    });
+
+    // TypeORM에서 배열 필드 검색이 제대로 작동하지 않을 수 있으므로 메모리에서 필터링
+    return groups.find((group) => group.memberUuid.includes(userUuid)) || null;
   }
 
-  findAll() {
-    return `This action returns all group`;
+  /**
+   * 그룹 생성
+   * @param createGroupDto 그룹 생성 정보
+   * @param ownerUuid 방장 UUID
+   * @returns 생성된 그룹 정보
+   */
+  async createGroup(
+    createGroupDto: CreateGroupDto,
+    ownerUuid: string,
+  ): Promise<Group> {
+    // 이미 다른 그룹에 소속되어 있는지 확인
+    const existingGroup = await this.findUserGroup(ownerUuid);
+    if (existingGroup) {
+      throw new BadRequestException(
+        '이미 다른 그룹에 소속되어 있습니다. 계정당 하나의 그룹만 가입할 수 있습니다.',
+      );
+    }
+
+    if (createGroupDto.password) {
+      createGroupDto.isAccessible = false;
+    } else {
+      createGroupDto.isAccessible = true;
+    }
+
+    const group = this.groupRepository.create({
+      ...createGroupDto,
+      ownerUuid,
+      memberUuid: [ownerUuid],
+    });
+
+    return this.groupRepository.save(group);
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} group`;
+  /**
+   * 그룹 수정
+   * @param groupId 그룹 ID
+   * @param updateGroupDto 그룹 수정 정보
+   * @param ownerUuid 방장 UUID
+   * @returns 수정된 그룹 정보
+   */
+  async updateGroup(
+    groupId: number,
+    updateGroupDto: UpdateGroupDto,
+    ownerUuid: string,
+  ): Promise<Group> {
+    const group = await this.groupRepository.findOne({
+      where: { id: groupId },
+    });
+
+    if (!group) {
+      throw new NotFoundException('해당 ID의 그룹을 찾을 수 없습니다.');
+    }
+
+    if (group.ownerUuid !== ownerUuid) {
+      throw new UnauthorizedException('이 그룹을 수정할 권한이 없습니다.');
+    }
+
+    if (updateGroupDto.password !== undefined) {
+      if (updateGroupDto.password) {
+        updateGroupDto.isAccessible = false;
+      } else {
+        updateGroupDto.isAccessible = true;
+      }
+    }
+
+    Object.assign(group, {
+      ...updateGroupDto,
+      updatedAt: new Date(),
+    });
+
+    return this.groupRepository.save(group);
   }
 
-  update(id: number, updateGroupDto: UpdateGroupDto) {
-    return `This action updates a #${id} group`;
+  /**
+   * 그룹 삭제
+   * @param groupId 그룹 ID
+   * @param ownerUuid 방장 UUID
+   * @returns 삭제 메시지
+   */
+  async deleteGroup(
+    groupId: number,
+    ownerUuid: string,
+  ): Promise<{ message: string }> {
+    const group = await this.groupRepository.findOne({
+      where: { id: groupId },
+    });
+
+    if (!group) {
+      throw new NotFoundException('해당 ID의 그룹을 찾을 수 없습니다.');
+    }
+
+    if (group.ownerUuid !== ownerUuid) {
+      throw new UnauthorizedException('이 그룹을 삭제할 권한이 없습니다.');
+    }
+
+    await this.groupRepository.delete(groupId);
+    return {
+      message: '그룹이 성공적으로 삭제되었습니다.',
+    };
   }
 
-  remove(id: number) {
-    return `This action removes a #${id} group`;
+  /**
+   * 모든 그룹 조회
+   * @param options 그룹 목록 조회 조건들
+   * @returns 모든 그룹 정보
+   */
+  async findAllGroups(options: { page: number; limit: number }) {
+    const { page, limit } = options;
+    const skip = (page - 1) * limit;
+
+    const [groups, total] = await this.groupRepository.findAndCount({
+      skip,
+      take: limit,
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+
+    return {
+      data: groups,
+      meta: {
+        totalItems: total,
+        itemsPerPage: limit,
+        totalPages: Math.ceil(total / limit),
+        currentPage: page,
+      },
+    };
+  }
+
+  /**
+   * 공개 그룹 조회
+   * @param options 그룹 목록 조회 조건들
+   * @returns 공개 그룹 정보
+   */
+  async findAccessibleGroups(options: { page: number; limit: number }) {
+    const { page, limit } = options;
+    const skip = (page - 1) * limit;
+
+    const whereCondition = {
+      isAccessible: true,
+    };
+
+    const [groups, total] = await this.groupRepository.findAndCount({
+      where: whereCondition,
+      skip,
+      take: limit,
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+
+    return {
+      data: groups,
+      meta: {
+        totalItems: total,
+        itemsPerPage: limit,
+        totalPages: Math.ceil(total / limit),
+        currentPage: page,
+      },
+    };
+  }
+
+  /**
+   * 그룹 제목 검색
+   * @param options 그룹 목록 조회 조건들
+   * @returns 그룹 목록 정보
+   */
+  async searchGroupsByTitle(options: {
+    page: number;
+    limit: number;
+    title: string;
+  }) {
+    const { page, limit, title } = options;
+    const skip = (page - 1) * limit;
+
+    const whereCondition: any = {
+      title: Like(`%${title}%`),
+      isAccessible: true,
+    };
+
+    const [groups, total] = await this.groupRepository.findAndCount({
+      where: whereCondition,
+      skip,
+      take: limit,
+      order: {
+        createdAt: 'DESC',
+      },
+    });
+
+    // 현재 멤버 수 계산
+    const groupsWithMemberCount = groups.map((group) => ({
+      ...group,
+      currentMembers: group.memberUuid.length,
+    }));
+
+    return {
+      data: groupsWithMemberCount,
+      meta: {
+        totalItems: total,
+        itemsPerPage: limit,
+        totalPages: Math.ceil(total / limit),
+        currentPage: page,
+      },
+    };
+  }
+
+  /**
+   * 그룹 상세 조회
+   * @param groupId 그룹 ID
+   * @returns 그룹 상세 정보
+   */
+  async findOneGroup(groupId: number): Promise<Group> {
+    const group = await this.groupRepository.findOne({
+      where: { id: groupId },
+    });
+
+    if (!group) {
+      throw new NotFoundException('해당 ID의 그룹을 찾을 수 없습니다.');
+    }
+
+    return group;
+  }
+
+  /**
+   * 사용자가 속한 그룹 조회
+   * @param userUuid 사용자 UUID
+   * @returns 사용자가 속한 그룹 정보 또는 null
+   */
+  async findUserCurrentGroup(userUuid: string): Promise<Group | null> {
+    return this.findUserGroup(userUuid);
+  }
+
+  /**
+   * 그룹 탈퇴
+   * @param groupId 그룹 ID
+   * @param userUuid 사용자 UUID
+   * @returns 탈퇴 메시지
+   */
+  async leaveGroup(
+    groupId: number,
+    userUuid: string,
+  ): Promise<{ message: string }> {
+    const group = await this.groupRepository.findOne({
+      where: { id: groupId },
+    });
+
+    if (!group) {
+      throw new NotFoundException('해당 ID의 그룹을 찾을 수 없습니다.');
+    }
+
+    // 방장은 그룹을 탈퇴할 수 없음
+    if (group.ownerUuid === userUuid) {
+      throw new BadRequestException(
+        '방장은 그룹을 탈퇴할 수 없습니다. 그룹을 삭제하세요.',
+      );
+    }
+
+    // 그룹에 속해있는지 확인
+    if (!group.memberUuid.includes(userUuid)) {
+      throw new BadRequestException('해당 그룹에 가입되어 있지 않습니다.');
+    }
+
+    // 멤버 목록에서 사용자 제거
+    group.memberUuid = group.memberUuid.filter((id) => id !== userUuid);
+    group.updatedAt = new Date();
+
+    await this.groupRepository.save(group);
+
+    return {
+      message: '그룹에서 성공적으로 탈퇴했습니다.',
+    };
+  }
+
+  /**
+   * 그룹 참여
+   * @param groupId 그룹 ID
+   * @param userUuid 사용자 UUID
+   * @param password 비밀번호 (선택적)
+   * @returns 참여된 그룹 정보
+   */
+  async joinGroup(
+    groupId: number,
+    userUuid: string,
+    password?: string,
+  ): Promise<Group> {
+    // 이미 다른 그룹에 소속되어 있는지 확인
+    const existingGroup = await this.findUserGroup(userUuid);
+    if (existingGroup) {
+      throw new BadRequestException(
+        '이미 다른 그룹에 소속되어 있습니다. 계정당 하나의 그룹만 가입할 수 있습니다.',
+      );
+    }
+
+    const group = await this.groupRepository.findOne({
+      where: { id: groupId },
+    });
+
+    if (!group) {
+      throw new NotFoundException('해당 ID의 그룹을 찾을 수 없습니다.');
+    }
+
+    // 이미 그룹에 속해 있는지 확인 (중복 체크)
+    if (group.memberUuid.includes(userUuid)) {
+      throw new BadRequestException('이미 그룹에 가입되어 있습니다.');
+    }
+
+    // 그룹이 최대 인원에 도달했는지 확인
+    if (group.memberUuid.length >= group.maxMember) {
+      throw new BadRequestException('그룹이 최대 인원에 도달했습니다.');
+    }
+
+    // 비공개 그룹인 경우 비밀번호 확인
+    if (!group.isAccessible) {
+      if (!password) {
+        throw new BadRequestException(
+          '그룹 참여를 위한 비밀번호가 필요합니다.',
+        );
+      }
+
+      if (group.password !== password) {
+        throw new UnauthorizedException('비밀번호가 일치하지 않습니다.');
+      }
+    }
+
+    // 멤버 목록에 사용자 추가
+    group.memberUuid.push(userUuid);
+    group.updatedAt = new Date();
+
+    return this.groupRepository.save(group);
   }
 }


### PR DESCRIPTION
## 🔗 이슈 번호
#19 
## ✅ 작업 내용

### ✔️ 구현 내용

- `POST api/group` 그룹 생성
- `GET api/group` 모든 공개 그룹 조회
- `GET api/group` 사용자가 속한 그룹 조회
- `GET api/group/{groupId}` 그룹 상세 조회
- `PATCH api/group/{groupId}` 그룹 수정
- `DELETE api/group/{groupId}` 그룹 삭제
- `POST api/group/{groupId}/join` 그룹 참여
- `DELETE api/group/{groupId}/leave` 그룹 탈퇴

‼️ Group APIs에 대한 자세한 내용은 Swagger API Docs 참고

### ⚙️ 주요 비즈니스 로직

- 사용자는 하나의 그룹에만 소속될 수 있음
- 그룹 생성 시 생성자는 자동으로 방장 및 멤버로 설정됨
- 비밀번호가 있는 그룹은 자동으로 비공개 그룹으로 설정됨
- 그룹 방장만 그룹을 수정/삭제할 수 있음
- 방장은 그룹을 탈퇴할 수 없으며, 그룹을 삭제해야 함

## 🗣️ 공유 사항
- 현재 ownerUuid/userUuid를 쿼리 파라미터로 전달받는 방식으로 구현
- 추후 JWT 토큰에서 사용자 UUID를 자동으로 추출하는 방식으로 변경할 예정
