### PR TITLE
[FEAT] post 작성 시 개인 통계 반영 및 그룹 랭킹 갱신 기능 추가

### DIFF
--- a/src/decorators/swagger.decorator.ts
+++ b/src/decorators/swagger.decorator.ts
@@ -3155,3 +3155,56 @@ export function ApiGetQuarterlyGroupRanking() {
     }),
   );
 }
+
+export function ApiUpdateIntroduction() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '소개글 수정',
+      description: '해당 유저의 소개글을 새로 수정합니다.',
+    }),
+    ApiParam({
+      name: 'userUuid',
+      type: 'string',
+      description: '소개글을 수정할 대상 유저의 UUID',
+      example: '123e4567-e89b-12d3-a456-426614174000',
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          newIntroduction: {
+            type: 'string',
+            example: '안녕하세요. 새로운 소개글입니다!',
+          },
+        },
+        required: ['newIntroduction'],
+      },
+    }),
+    ApiResponse({
+      status: 200,
+      description: '소개글 변경 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '소개글 변경 성공!',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '유저를 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '사용자를 찾을 수 없습니다.',
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/modules/group/group.service.ts
+++ b/src/modules/group/group.service.ts
@@ -22,7 +22,7 @@ export class GroupService {
    * @param userUuid 사용자 UUID
    * @returns 사용자가 소속된 그룹 또는 null
    */
-  private async findUserGroup(userUuid: string): Promise<Group | null> {
+  async findUserGroup(userUuid: string): Promise<Group | null> {
     // memberUuid 배열에 사용자 UUID가 포함된 그룹 찾기
     const groups = await this.groupRepository.find({
       where: {},

--- a/src/modules/posts/posts.module.ts
+++ b/src/modules/posts/posts.module.ts
@@ -9,10 +9,11 @@ import { GroupModule } from '../group/group.module';
 import { User } from '@/entities/user.entity';
 import { UsersModule } from '../users/users.module';
 import { WorkoutLog } from '@/entities/workout-log.entity';
+import { QuarterlyStatistics } from '@/entities/quarterly-statistics.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Post, User, WorkoutLog]),
+    TypeOrmModule.forFeature([Post, User, WorkoutLog, QuarterlyStatistics]),
     forwardRef(() => LikesModule),
     forwardRef(() => CommentsModule),
     forwardRef(() => GroupModule),

--- a/src/modules/posts/posts.module.ts
+++ b/src/modules/posts/posts.module.ts
@@ -10,10 +10,17 @@ import { User } from '@/entities/user.entity';
 import { UsersModule } from '../users/users.module';
 import { WorkoutLog } from '@/entities/workout-log.entity';
 import { QuarterlyStatistics } from '@/entities/quarterly-statistics.entity';
+import { QuarterlyRanking } from '@/entities/quarterly-ranking.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Post, User, WorkoutLog, QuarterlyStatistics]),
+    TypeOrmModule.forFeature([
+      Post,
+      User,
+      WorkoutLog,
+      QuarterlyStatistics,
+      QuarterlyRanking,
+    ]),
     forwardRef(() => LikesModule),
     forwardRef(() => CommentsModule),
     forwardRef(() => GroupModule),

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -8,7 +8,7 @@ import {
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
+import { Between, In, Repository } from 'typeorm';
 import { FindAllPostsDto } from './dto/find-all-posts.dto';
 import { Post } from '@/entities/post.entity';
 import { WorkoutLog } from '@/entities/workout-log.entity';
@@ -19,6 +19,7 @@ import { FindPopularPostsDto } from './dto/find-popular-posts.dto';
 import { FindGroupPostsDto } from './dto/find-group-posts.dto';
 import { User } from '@/entities/user.entity';
 import { UsersService } from '../users/users.service';
+import { QuarterlyStatistics } from '@/entities/quarterly-statistics.entity';
 
 @Injectable()
 export class PostsService {
@@ -27,6 +28,8 @@ export class PostsService {
     private postRepository: Repository<Post>,
     @InjectRepository(WorkoutLog)
     private workoutLogRepository: Repository<WorkoutLog>,
+    @InjectRepository(QuarterlyStatistics)
+    private quarterlyStatisticsRepository: Repository<QuarterlyStatistics>,
     private likesService: LikesService,
     @Inject(forwardRef(() => CommentsService))
     private commentsService: CommentsService,
@@ -46,6 +49,22 @@ export class PostsService {
     const { title, content, imageUrl, isPublic, bodyPart, duration } =
       createPostDto;
 
+    // 오늘 작성한 글 있는지 확인
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+    const todayEnd = new Date();
+    todayEnd.setHours(23, 59, 59, 999);
+    const now = new Date();
+    const year = now.getFullYear();
+    const quarter = Math.floor(now.getMonth() / 3) + 1;
+
+    const alreadyPostedToday = await this.postRepository.exists({
+      where: {
+        userUuid,
+        createdAt: Between(todayStart, todayEnd),
+      },
+    });
+
     const post = this.postRepository.create({
       title,
       content,
@@ -54,6 +73,67 @@ export class PostsService {
       userUuid,
     });
     const savedPost = await this.postRepository.save(post);
+
+    // kst 시간대 구분 함수
+    function getCurrentKSTTimeZoneLabel():
+      | 'dawn'
+      | 'morning'
+      | 'afternoon'
+      | 'night' {
+      const utcNow = new Date();
+      const kstNow = new Date(utcNow.getTime() + 9 * 60 * 60 * 1000); // + 9시간 보정
+      const hour = kstNow.getUTCHours(); // 보정된 시간 기준으로 getUTCHours()
+
+      if (hour < 6) return 'dawn';
+      if (hour < 12) return 'morning';
+      if (hour < 18) return 'afternoon';
+      return 'night';
+    }
+    const timeZoneLabel = getCurrentKSTTimeZoneLabel();
+
+    // 오늘 올린 post가 없다면 그룹 통계에 집계
+    if (!alreadyPostedToday) {
+    }
+
+    // 개인 통계 집계
+    let stat = await this.quarterlyStatisticsRepository.findOne({
+      where: { userUuid, year, quarter },
+    });
+
+    if (!stat) {
+      // 처음이면 통계 엔트리 생성
+      const initialBodyPart = {};
+      for (const part of bodyPart) {
+        initialBodyPart[part] = 1;
+      }
+      const initalTimeZone = { dawn: 0, morning: 0, afternoon: 0, night: 0 };
+      initalTimeZone[timeZoneLabel] = 1;
+
+      stat = this.quarterlyStatisticsRepository.create({
+        userUuid,
+        year,
+        quarter,
+        timeZone: initalTimeZone,
+        bodyPart: initialBodyPart,
+        currentStreak: alreadyPostedToday ? 0 : 1,
+        longestStreak: alreadyPostedToday ? 0 : 1,
+      });
+    } else {
+      for (const part of bodyPart) {
+        stat.bodyPart[part] = (stat.bodyPart[part] || 0) + 1;
+      }
+
+      stat.timeZone[timeZoneLabel] = (stat.timeZone[timeZoneLabel] || 0) + 1;
+
+      if (!alreadyPostedToday) {
+        stat.currentStreak += 1;
+        if (stat.currentStreak > stat.longestStreak) {
+          stat.longestStreak = stat.currentStreak;
+        }
+      }
+    }
+
+    await this.quarterlyStatisticsRepository.save(stat);
 
     if (duration && bodyPart?.length > 0) {
       for (const part of bodyPart) {


### PR DESCRIPTION
## 🔗 이슈 번호

#55 

## ✅ 작업 내용

- 게시글 작성시 개인 통계 반영
- 게시글 작성시 그룹 랭킹 갱신(점수 반영)

## 🗣️ 공유 사항
- 아직 그룹 랭킹 쪽 streak, rate, commit 부분은 건드리지 못했습니다..이거는 좀 더 고민해봐야할 것 같습니다
