### PR TITLE
[FIX] 좋아요 생성 시 userUuid 누락 에러 픽스

### DIFF
--- a/src/decorators/swagger.decorator.ts
+++ b/src/decorators/swagger.decorator.ts
@@ -1292,12 +1292,6 @@ export function ApiCreateLike() {
       schema: {
         type: 'object',
         properties: {
-          userUuid: {
-            type: 'string',
-            format: 'uuid',
-            description: '좋아요를 추가할 사용자 UUID',
-            example: '123e4567-e89b-12d3-a456-426614174000',
-          },
           postId: {
             type: 'integer',
             description: '좋아요를 추가할 게시글 ID',
@@ -1404,13 +1398,6 @@ export function ApiCheckLikeStatus() {
       required: true,
       type: 'string',
     }),
-    ApiParam({
-      name: 'userUuid',
-      description: '확인할 사용자 UUID',
-      example: '123e4567-e89b-12d3-a456-426614174000',
-      required: true,
-      type: 'string',
-    }),
     ApiResponse({
       status: 200,
       description: '좋아요 상태 확인 성공',
@@ -1437,13 +1424,6 @@ export function ApiDeleteLike() {
     ApiParam({
       name: 'postId',
       description: '게시글 ID',
-      required: true,
-      type: 'string',
-    }),
-    ApiParam({
-      name: 'userUuid',
-      description: '사용자 UUID',
-      example: '123e4567-e89b-12d3-a456-426614174000',
       required: true,
       type: 'string',
     }),

--- a/src/modules/likes/likes.service.ts
+++ b/src/modules/likes/likes.service.ts
@@ -45,6 +45,7 @@ export class LikesService {
     const like = this.likeRepository.create({
       ...createLikeDto,
       userId,
+      userUuid,
     });
 
     await this.likeRepository.save(like);


### PR DESCRIPTION
## 🔗 이슈 번호
#63 
## ✅ 작업 내용
- `LikesService`의 `createLike` 메서드에서 좋아요 생성 시 `userUuid` 필드가 누락되어 발생하던 문제 해결
- 좋아요 생성 시 `userUuid`를 함께 저장하도록 수정
- 데이터베이스의 not-null 제약조건 위반 문제 해결
## 🗣️ 공유 사항
