### PR TITLE
[FIX] post 상세조회 workout_log 추가

### DIFF
--- a/src/modules/likes/likes.controller.ts
+++ b/src/modules/likes/likes.controller.ts
@@ -45,7 +45,7 @@ export class LikesController {
    * @param userUuid 사용자 UUID
    * @returns 좋아요 여부와 좋아요 ID
    */
-  @Get('check/:postId/:userUuid')
+  @Get('check/:postId')
   @ApiCheckLikeStatus()
   checkLikeStatus(
     @Param('postId') postId: string,
@@ -60,7 +60,7 @@ export class LikesController {
    * @param userUuid 사용자 UUID
    * @returns 삭제 성공 메시지와 업데이트된 좋아요 수
    */
-  @Delete('post/:postId/user/:userUuid')
+  @Delete('post/:postId/user')
   @ApiDeleteLike()
   removeLike(@Param('postId') postId: string, @UserUuid() userUuid: string) {
     return this.likesService.removeLike(+postId, userUuid);

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -269,6 +269,15 @@ export class PostsService {
       select: ['id', 'nickname', 'profileImage'],
     });
 
+    // 운동 로그 정보 조회
+    const workoutLogs = await this.workoutLogRepository.find({
+      where: { postId: id },
+    });
+
+    // 운동 정보 집계
+    const bodyPart = [...new Set(workoutLogs.flatMap((log) => log.bodyPart))];
+    const duration = workoutLogs.reduce((sum, log) => sum + log.duration, 0);
+
     const likeCount = await this.likesService.getLikeCountByPostId(id);
     const comments = await this.commentsService.getCommentsByPostId(
       id,
@@ -281,6 +290,8 @@ export class PostsService {
 
     return {
       ...post,
+      bodyPart,
+      duration,
       likeCount,
       commentCount,
       userLiked: likeStatus?.liked ?? false,


### PR DESCRIPTION
## 🔗 이슈 번호
#64 
## ✅ 작업 내용
- 게시글 상세 조회 시 운동 정보(`bodyPart`, `duration`) 포함하도록 수정
- `WorkoutLog` 엔티티에서 해당 게시글의 운동 로그 정보 조회
## 🗣️ 공유 사항
