### PR TITLE
[REFACTOR] 그룹 조회 API 응답 개선

### DIFF
--- a/src/modules/group/group.module.ts
+++ b/src/modules/group/group.module.ts
@@ -3,9 +3,10 @@ import { GroupService } from './group.service';
 import { GroupController } from './group.controller';
 import { Group } from '@/entities/group.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
-
+import { UsersModule } from '../users/users.module';
+import { forwardRef } from '@nestjs/common';
 @Module({
-  imports: [TypeOrmModule.forFeature([Group])],
+  imports: [TypeOrmModule.forFeature([Group]), forwardRef(() => UsersModule)],
   controllers: [GroupController],
   providers: [GroupService],
   exports: [GroupService],

--- a/src/modules/posts/posts.service.ts
+++ b/src/modules/posts/posts.service.ts
@@ -104,7 +104,7 @@ export class PostsService {
       if (isGroup) {
         const groupId = isGroup.id;
 
-        const group = await this.groupService.findOneGroup(groupId);
+        const group = await this.groupService.findOneGroup(groupId, userUuid);
         const currentMembers = group.memberUuid.length;
         const score = (1 / currentMembers) * 100;
 
@@ -403,7 +403,7 @@ export class PostsService {
     findGroupPostsDto: FindGroupPostsDto,
     userUuid: string,
   ) {
-    const group = await this.groupService.findOneGroup(groupId);
+    const group = await this.groupService.findOneGroup(groupId, userUuid);
 
     if (!group) {
       throw new NotFoundException('해당 ID의 그룹을 찾을 수 없습니다.');


### PR DESCRIPTION
## 📌 이슈 번호
#72

## ✅ 작업 내용
- 그룹 조회 API 응답 개선

### 변경 사항
1. 그룹 조회 시 민감 정보 제외
   - `ownerUuid`, `memberUuid`, `password` 필드 제외
   - 구조 분해 할당을 사용하여 안전한 정보만 반환하도록 수정

2. 그룹원 정보 상세화
   - UUID 대신 사용자 상세 정보 반환
   - 프로필 이미지, 닉네임, 소개글 포함
   - 각 그룹원의 방장 여부 표시

3. 현재 로그인한 사용자의 방장 여부 표시
   - `isOwner` 필드 추가
   - 현재 사용자의 UUID와 그룹의 `ownerUuid` 비교

### 변경된 API 응답 예시
```json
{
  "id": 1,
  "title": "오운완",
  "isAccessible": true,
  "maxMember": 4,
  "createdAt": "2025-05-14T05:05:19.169Z",
  "updatedAt": "2025-05-14T05:05:19.169Z",
  "isOwner": true,
  "members": [
    {
      "userName": "홍길동",
      "userImage": "https://example.com/profile1.jpg",
      "userIntroduction": "안녕하세요"
    }
  ]
}
```